### PR TITLE
chore: remove the variable jenkins_nonroot

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,38 +1,35 @@
-jenkins-ubuntu
-================
+# jenkins-ubuntu
 
 [![Build Status](https://travis-ci.org/suzuki-shunsuke/ansible-jenkins-ubuntu.svg?branch=master)](https://travis-ci.org/suzuki-shunsuke/ansible-jenkins-ubuntu)
 
-Install Jenkins on Ubuntu.
+ansible role to install Jenkins on Ubuntu.
 
 https://galaxy.ansible.com/suzuki-shunsuke/jenkins-ubuntu/
 
-Requirements
-------------
+## Requirements
 
 Nothing.
 
-Role Variables
---------------
+## Role Variables
 
-* jenkins_jre: JRE apt package name. The default is "openjdk-8-jre"
-* jenkins_jdk: JDK apt package name. The default is "openjdk-8-jdk"
+name | required | default | description
+--- | --- | --- | ---
+jenkins_jre | no | openjdk-8-jre | JRE apt package name
+jenkins_jdk | no | openjdk-8-jdk | JDK apt package name
 
-Dependencies
-------------
+## Dependencies
 
 Nothing.
 
-Example Playbook
-----------------
+## Example Playbook
 
 ```yaml
 - hosts: servers
   roles:
-  - suzuki-shunsuke.jenkins-ubuntu
+  - role: suzuki-shunsuke.jenkins-ubuntu
+    become: yes
 ```
 
-License
--------
+## License
 
-MIT
+[MIT](LICENSE)

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -5,22 +5,18 @@
     name: "{{ item }}"
     update_cache: yes
     install_recommends: no
-  become: "{{ jenkins_nonroot }}"
   items:
   - "{{ jenkins_jre }}"
   - "{{ jenkins_jdk }}"
 - name: Add APT key
   apt_key:
     url: https://pkg.jenkins.io/debian/jenkins-ci.org.key
-  become: "{{ jenkins_nonroot }}"
 - name: Copy jenkins.list to /etc/apt/sources.list.d/jenkins.list
   copy:
     src: jenkins.list
     dest: /etc/apt/sources.list.d/jenkins.list
-  become: "{{ jenkins_nonroot }}"
 - name: Install Jenkins
   apt: 
     name: jenkins
     update_cache: yes
     install_recommends: no
-  become: "{{ jenkins_nonroot }}"

--- a/tests/test.yml
+++ b/tests/test.yml
@@ -1,4 +1,5 @@
 ---
 - hosts: default
   roles:
-  - ansible-jenkins-ubuntu
+  - role: ansible-jenkins-ubuntu
+    become: yes

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -1,3 +1,0 @@
----
-# vars file for jenkins-ubuntu
-jenkins_nonroot: "{{ (ansible_env.HOME == '/root') | ternary('no', 'yes') }}"


### PR DESCRIPTION
BREAKING CHANGE: `become: yes` is required unless the remote user is root